### PR TITLE
Fix FileNotFoundErrors to support windows

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ biom 2.1.15-dev
 
 Performance improvements:
 
+* Add Windows support. PR[#951](https://github.com/biocore/biom-format/pull/951) revises codebase to be Winows compatible and adds this support to the CI testing matrix.
 * Add NumPy 2.0 support. PR [#950](https://github.com/biocore/biom-format/pull/950) ensures code compatibility with NumPy 2.0. This support is yet to be added to the CI testing matrix.
 * Revise `Table._fast_merge` to use COO directly. For very large tables, this reduces runtime by ~50x and memory by ~5x. See PR [#913](https://github.com/biocore/biom-format/pull/933).
 * Drastically reduce the memory needs of subsampling when sums are large. Also adds 64-bit support. See PR [#935](https://github.com/biocore/biom-format/pull/935).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ biom 2.1.15-dev
 
 Performance improvements:
 
-* Add Windows support. PR[#951](https://github.com/biocore/biom-format/pull/951) revises codebase to be Winows compatible and adds this support to the CI testing matrix.
+* Add Windows support. PR[#951](https://github.com/biocore/biom-format/pull/951) revises codebase to be Windows compatible and adds this support to the CI testing matrix.
 * Add NumPy 2.0 support. PR [#950](https://github.com/biocore/biom-format/pull/950) ensures code compatibility with NumPy 2.0. This support is yet to be added to the CI testing matrix.
 * Revise `Table._fast_merge` to use COO directly. For very large tables, this reduces runtime by ~50x and memory by ~5x. See PR [#913](https://github.com/biocore/biom-format/pull/933).
 * Drastically reduce the memory needs of subsampling when sums are large. Also adds 64-bit support. See PR [#935](https://github.com/biocore/biom-format/pull/935).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ biom 2.1.15-dev
 
 Performance improvements:
 
+* Add NumPy 2.0 support. PR [#950](https://github.com/biocore/biom-format/pull/950) ensures code compatibility with NumPy 2.0. This support is yet to be added to the CI testing matrix.
 * Revise `Table._fast_merge` to use COO directly. For very large tables, this reduces runtime by ~50x and memory by ~5x. See PR [#913](https://github.com/biocore/biom-format/pull/933).
 * Drastically reduce the memory needs of subsampling when sums are large. Also adds 64-bit support. See PR [#935](https://github.com/biocore/biom-format/pull/935).
 * Improve handling of not-perfectly-integer inputs. See PR [#938](https://github.com/biocore/biom-format/pull/938).

--- a/biom/_filter.pyx
+++ b/biom/_filter.pyx
@@ -13,6 +13,7 @@ from types import FunctionType
 
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
 
 
 cdef cnp.ndarray[cnp.uint8_t, ndim=1] \

--- a/biom/_subsample.pyx
+++ b/biom/_subsample.pyx
@@ -8,6 +8,8 @@
 
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
+
 
 cdef _subsample_with_replacement(cnp.ndarray[cnp.float64_t, ndim=1] data,
                                  cnp.ndarray[cnp.int32_t, ndim=1] indptr,

--- a/biom/_transform.pyx
+++ b/biom/_transform.pyx
@@ -9,6 +9,7 @@
 
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
 
 
 def _transform(arr, ids, metadata, function, axis):

--- a/biom/tests/test_cli/test_add_metadata.py
+++ b/biom/tests/test_cli/test_add_metadata.py
@@ -9,6 +9,7 @@
 # -----------------------------------------------------------------------------
 
 import tempfile
+import os
 from unittest import TestCase, main
 
 import biom
@@ -20,10 +21,12 @@ class TestAddMetadata(TestCase):
     def setUp(self):
         """Set up data for use in unit tests."""
         self.cmd = _add_metadata
-        with tempfile.NamedTemporaryFile('w') as fh:
+        with tempfile.NamedTemporaryFile('w', delete=False) as fh:
             fh.write(biom1)
             fh.flush()
             self.biom_table1 = biom.load_table(fh.name)
+            fh.close()
+            os.unlink(fh.name)
         self.sample_md_lines1 = sample_md1.split('\n')
         self.obs_md_lines1 = obs_md1.split('\n')
 

--- a/biom/tests/test_cli/test_add_metadata.py
+++ b/biom/tests/test_cli/test_add_metadata.py
@@ -31,6 +31,7 @@ class TestAddMetadata(TestCase):
 
     def tearDown(self):
         os.unlink(self.temporary_fh_name)
+        self.test_workflow = True
 
     def test_add_sample_metadata_no_casting(self):
         """Correctly adds sample metadata without casting it."""

--- a/biom/tests/test_cli/test_add_metadata.py
+++ b/biom/tests/test_cli/test_add_metadata.py
@@ -25,9 +25,12 @@ class TestAddMetadata(TestCase):
             fh.write(biom1)
             fh.flush()
             self.biom_table1 = biom.load_table(fh.name)
-        os.unlink(fh.name)
+            self.temporary_fh_name = fh.name
         self.sample_md_lines1 = sample_md1.split('\n')
         self.obs_md_lines1 = obs_md1.split('\n')
+
+    def tearDown(self):
+        os.unlink(self.temporary_fh_name)
 
     def test_add_sample_metadata_no_casting(self):
         """Correctly adds sample metadata without casting it."""

--- a/biom/tests/test_cli/test_add_metadata.py
+++ b/biom/tests/test_cli/test_add_metadata.py
@@ -25,8 +25,7 @@ class TestAddMetadata(TestCase):
             fh.write(biom1)
             fh.flush()
             self.biom_table1 = biom.load_table(fh.name)
-            fh.close()
-            os.unlink(fh.name)
+        os.unlink(fh.name)
         self.sample_md_lines1 = sample_md1.split('\n')
         self.obs_md_lines1 = obs_md1.split('\n')
 

--- a/biom/tests/test_cli/test_add_metadata.py
+++ b/biom/tests/test_cli/test_add_metadata.py
@@ -31,7 +31,6 @@ class TestAddMetadata(TestCase):
 
     def tearDown(self):
         os.unlink(self.temporary_fh_name)
-        self.test_workflow = True
 
     def test_add_sample_metadata_no_casting(self):
         """Correctly adds sample metadata without casting it."""

--- a/biom/tests/test_cli/test_subset_table.py
+++ b/biom/tests/test_cli/test_subset_table.py
@@ -56,7 +56,7 @@ class TestSubsetTable(unittest.TestCase):
         """Correctly subsets samples in a hdf5 table"""
         cwd = os.getcwd()
         if os.path.sep in __file__:
-            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
+            os.chdir(os.path.dirname(__file__))
         obs = _subset_table(hdf5_biom=os.path.join('test_data', 'test.biom'),
                             axis='sample',
                             ids=['Sample1', 'Sample2', 'Sample3'],
@@ -73,7 +73,7 @@ class TestSubsetTable(unittest.TestCase):
         """Correctly subsets samples in a hdf5 table"""
         cwd = os.getcwd()
         if os.path.sep in __file__:
-            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
+            os.chdir(os.path.dirname(__file__))
         obs = _subset_table(hdf5_biom=os.path.join('test_data', 'test.biom'),
                             axis='observation',
                             ids=['GG_OTU_1', 'GG_OTU_3', 'GG_OTU_5'],

--- a/biom/tests/test_cli/test_subset_table.py
+++ b/biom/tests/test_cli/test_subset_table.py
@@ -55,9 +55,10 @@ class TestSubsetTable(unittest.TestCase):
     def test_subset_samples_hdf5(self):
         """Correctly subsets samples in a hdf5 table"""
         cwd = os.getcwd()
-        if '/' in __file__:
-            os.chdir(__file__.rsplit('/', 1)[0])
-        obs = _subset_table(hdf5_biom='test_data/test.biom', axis='sample',
+        if os.path.sep in __file__:
+            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
+        obs = _subset_table(hdf5_biom=os.path.join('test_data', 'test.biom'),
+                            axis='sample',
                             ids=['Sample1', 'Sample2', 'Sample3'],
                             json_table_str=None)
         os.chdir(cwd)
@@ -71,9 +72,9 @@ class TestSubsetTable(unittest.TestCase):
     def test_subset_observations_hdf5(self):
         """Correctly subsets samples in a hdf5 table"""
         cwd = os.getcwd()
-        if '/' in __file__:
-            os.chdir(__file__.rsplit('/', 1)[0])
-        obs = _subset_table(hdf5_biom='test_data/test.biom',
+        if os.path.sep in __file__:
+            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
+        obs = _subset_table(hdf5_biom=os.path.join('test_data', 'test.biom'),
                             axis='observation',
                             ids=['GG_OTU_1', 'GG_OTU_3', 'GG_OTU_5'],
                             json_table_str=None)

--- a/biom/tests/test_cli/test_summarize_table.py
+++ b/biom/tests/test_cli/test_summarize_table.py
@@ -23,7 +23,10 @@ class TestSummarizeTable(TestCase):
             fh.write(biom1)
             fh.flush()
             self.biom1 = load_table(fh.name)
-        os.unlink(fh.name)
+            self.temporary_fh_name = fh.name
+
+    def tearDown(self):
+        os.unlink(self.temporary_fh_name)
 
     def test_default(self):
         """ TableSummarizer functions as expected

--- a/biom/tests/test_cli/test_summarize_table.py
+++ b/biom/tests/test_cli/test_summarize_table.py
@@ -23,8 +23,7 @@ class TestSummarizeTable(TestCase):
             fh.write(biom1)
             fh.flush()
             self.biom1 = load_table(fh.name)
-            fh.close()
-            os.unlink(fh.name)
+        os.unlink(fh.name)
 
     def test_default(self):
         """ TableSummarizer functions as expected

--- a/biom/tests/test_cli/test_summarize_table.py
+++ b/biom/tests/test_cli/test_summarize_table.py
@@ -12,16 +12,19 @@ from biom.cli.table_summarizer import _summarize_table
 from biom.parse import load_table
 
 import tempfile
+import os
 from unittest import TestCase, main
 
 
 class TestSummarizeTable(TestCase):
 
     def setUp(self):
-        with tempfile.NamedTemporaryFile(mode='w') as fh:
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as fh:
             fh.write(biom1)
             fh.flush()
             self.biom1 = load_table(fh.name)
+            fh.close()
+            os.unlink(fh.name)
 
     def test_default(self):
         """ TableSummarizer functions as expected

--- a/biom/tests/test_cli/test_table_converter.py
+++ b/biom/tests/test_cli/test_table_converter.py
@@ -41,8 +41,7 @@ class TableConverterTests(TestCase):
             fh.write(classic1)
             fh.flush()
             self.classic_biom1 = load_table(fh.name)
-            fh.close()
-            os.unlink(fh.name)
+        os.unlink(fh.name)
 
         self.sample_md1 = MetadataMap.from_file(sample_md1.split('\n'))
 

--- a/biom/tests/test_cli/test_table_converter.py
+++ b/biom/tests/test_cli/test_table_converter.py
@@ -8,6 +8,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # -----------------------------------------------------------------------------
 
+import os
 from os.path import abspath, dirname, join
 import tempfile
 
@@ -28,16 +29,20 @@ class TableConverterTests(TestCase):
         self.cmd = _convert
         self.output_filepath = tempfile.NamedTemporaryFile().name
 
-        with tempfile.NamedTemporaryFile('w') as fh:
+        with tempfile.NamedTemporaryFile('w', delete=False) as fh:
             fh.write(biom1)
             fh.flush()
             self.biom_table1 = load_table(fh.name)
+            fh.close()
+            os.unlink(fh.name)
 
         self.biom_lines1 = biom1.split('\n')
-        with tempfile.NamedTemporaryFile('w') as fh:
+        with tempfile.NamedTemporaryFile('w', delete=False) as fh:
             fh.write(classic1)
             fh.flush()
             self.classic_biom1 = load_table(fh.name)
+            fh.close()
+            os.unlink(fh.name)
 
         self.sample_md1 = MetadataMap.from_file(sample_md1.split('\n'))
 

--- a/biom/tests/test_cli/test_table_converter.py
+++ b/biom/tests/test_cli/test_table_converter.py
@@ -33,15 +33,14 @@ class TableConverterTests(TestCase):
             fh.write(biom1)
             fh.flush()
             self.biom_table1 = load_table(fh.name)
-            fh.close()
-            os.unlink(fh.name)
+            self.temporary_fh_table_name = fh.name
 
         self.biom_lines1 = biom1.split('\n')
         with tempfile.NamedTemporaryFile('w', delete=False) as fh:
             fh.write(classic1)
             fh.flush()
             self.classic_biom1 = load_table(fh.name)
-        os.unlink(fh.name)
+            self.temporary_fh_classic_name = fh.name
 
         self.sample_md1 = MetadataMap.from_file(sample_md1.split('\n'))
 
@@ -50,6 +49,10 @@ class TableConverterTests(TestCase):
                                        'json_obs_collapsed.biom')
         self.json_collapsed_samples = join(test_data_dir,
                                            'json_sample_collapsed.biom')
+
+    def tearDown(self):
+        os.unlink(self.temporary_fh_classic_name)
+        os.unlink(self.temporary_fh_table_name)
 
     def test_classic_to_biom(self):
         """Correctly converts classic to biom."""

--- a/biom/tests/test_cli/test_table_normalizer.py
+++ b/biom/tests/test_cli/test_table_normalizer.py
@@ -24,9 +24,9 @@ class TableNormalizerTests(TestCase):
         self.cmd = _normalize_table
 
         cwd = os.getcwd()
-        if '/' in __file__:
-            os.chdir(__file__.rsplit('/', 1)[0])
-        self.table = biom.load_table('test_data/test.json')
+        if os.path.sep in __file__:
+            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
+        self.table = biom.load_table(os.path.join('test_data', 'test.json'))
         os.chdir(cwd)
 
     def test_bad_inputs(self):

--- a/biom/tests/test_cli/test_table_normalizer.py
+++ b/biom/tests/test_cli/test_table_normalizer.py
@@ -25,7 +25,7 @@ class TableNormalizerTests(TestCase):
 
         cwd = os.getcwd()
         if os.path.sep in __file__:
-            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
+            os.chdir(os.path.dirname(__file__))
         self.table = biom.load_table(os.path.join('test_data', 'test.json'))
         os.chdir(cwd)
 

--- a/biom/tests/test_cli/test_validate_table.py
+++ b/biom/tests/test_cli/test_validate_table.py
@@ -39,7 +39,8 @@ class TableValidatorTests(TestCase):
         self.to_remove = []
 
         cur_path = os.path.split(os.path.abspath(__file__))[0]
-        examples_path = os.path.join(cur_path.rsplit('/', 3)[0], 'examples')
+        examples_path = os.path.join(cur_path.rsplit(os.path.sep, 3)[0],
+                                     'examples')
         self.hdf5_file_valid = os.path.join(examples_path,
                                             'min_sparse_otu_table_hdf5.biom')
         self.hdf5_file_valid_md = os.path.join(examples_path,

--- a/biom/tests/test_parse.py
+++ b/biom/tests/test_parse.py
@@ -355,7 +355,8 @@ class ParseTests(TestCase):
         if os.path.sep in __file__[1:]:
             os.chdir(os.path.dirname(__file__))
 
-        t = parse_biom_table(h5py.File(os.path.join('test_data', 'test.biom'), 'r'))
+        t = parse_biom_table(h5py.File(os.path.join('test_data', 'test.biom'),
+                                       'r'))
 
         # These things are not round-trippable using the general-purpose
         # parse_biom_table function

--- a/biom/tests/test_parse.py
+++ b/biom/tests/test_parse.py
@@ -281,9 +281,10 @@ class ParseTests(TestCase):
     def test_parse_biom_table_hdf5(self):
         """Make sure we can parse a HDF5 table through the same loader"""
         cwd = os.getcwd()
-        if '/' in __file__[1:]:
-            os.chdir(__file__.rsplit('/', 1)[0])
-        Table.from_hdf5(h5py.File('test_data/test.biom', 'r'))
+        if os.path.sep in __file__[1:]:
+            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
+        Table.from_hdf5(h5py.File(os.path.join('test_data', 'test.biom'),
+                                  'r'))
         os.chdir(cwd)
 
     def test_save_table_filepath(self):
@@ -296,23 +297,23 @@ class ParseTests(TestCase):
 
     def test_load_table_filepath(self):
         cwd = os.getcwd()
-        if '/' in __file__[1:]:
-            os.chdir(__file__.rsplit('/', 1)[0])
-        load_table('test_data/test.biom')
+        if os.path.sep in __file__[1:]:
+            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
+        load_table(os.path.join('test_data', 'test.biom'))
         os.chdir(cwd)
 
     def test_load_table_inmemory(self):
         cwd = os.getcwd()
-        if '/' in __file__[1:]:
-            os.chdir(__file__.rsplit('/', 1)[0])
-        load_table(h5py.File('test_data/test.biom', 'r'))
+        if os.path.sep in __file__[1:]:
+            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
+        load_table(h5py.File(os.path.join('test_data', 'test.biom'), 'r'))
         os.chdir(cwd)
 
     def test_load_table_inmemory_json(self):
         cwd = os.getcwd()
-        if '/' in __file__[1:]:
-            os.chdir(__file__.rsplit('/', 1)[0])
-        load_table(open('test_data/test.json'))
+        if os.path.sep in __file__[1:]:
+            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
+        load_table(open(os.path.join('test_data', 'test.json')))
         os.chdir(cwd)
 
     def test_load_table_inmemory_stringio(self):
@@ -350,10 +351,10 @@ class ParseTests(TestCase):
         """tests for parse_biom_table when we have h5py"""
         # We will round-trip the HDF5 file to several different formats, and
         # make sure we can recover the same table using parse_biom_table
-        if '/' in __file__[1:]:
-            os.chdir(__file__.rsplit('/', 1)[0])
+        if os.path.sep in __file__[1:]:
+            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
 
-        t = parse_biom_table(h5py.File('test_data/test.biom', 'r'))
+        t = parse_biom_table(h5py.File(os.path.join('test_data', 'test.biom'), 'r'))
 
         # These things are not round-trippable using the general-purpose
         # parse_biom_table function

--- a/biom/tests/test_parse.py
+++ b/biom/tests/test_parse.py
@@ -290,10 +290,11 @@ class ParseTests(TestCase):
     def test_save_table_filepath(self):
         t = Table(np.array([[0, 1, 2], [3, 4, 5]]), ['a', 'b'],
                   ['c', 'd', 'e'])
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             save_table(t, tmpfile.name)
             obs = load_table(tmpfile.name)
             self.assertEqual(obs, t)
+        os.unlink(tmpfile.name)
 
     def test_load_table_filepath(self):
         cwd = os.getcwd()

--- a/biom/tests/test_parse.py
+++ b/biom/tests/test_parse.py
@@ -46,13 +46,18 @@ class ParseTests(TestCase):
         self.legacy_otu_table1 = legacy_otu_table1
         self.otu_table1 = otu_table1
         self.otu_table1_floats = otu_table1_floats
-        self.files_to_remove = []
+        self.to_remove = []
         self.biom_minimal_sparse = biom_minimal_sparse
 
         self.classic_otu_table1_w_tax = classic_otu_table1_w_tax.split('\n')
         self.classic_otu_table1_no_tax = classic_otu_table1_no_tax.split('\n')
         self.classic_table_with_complex_metadata = \
             classic_table_with_complex_metadata.split('\n')
+
+    def tearDown(self):
+        if self.to_remove:
+            for f in self.to_remove:
+                os.remove(f)
 
     def test_from_tsv_bug_854(self):
         data = StringIO('#FeatureID\tSample1')
@@ -294,7 +299,7 @@ class ParseTests(TestCase):
             save_table(t, tmpfile.name)
             obs = load_table(tmpfile.name)
             self.assertEqual(obs, t)
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
 
     def test_load_table_filepath(self):
         cwd = os.getcwd()

--- a/biom/tests/test_parse.py
+++ b/biom/tests/test_parse.py
@@ -282,7 +282,7 @@ class ParseTests(TestCase):
         """Make sure we can parse a HDF5 table through the same loader"""
         cwd = os.getcwd()
         if os.path.sep in __file__[1:]:
-            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
+            os.chdir(os.path.dirname(__file__))
         Table.from_hdf5(h5py.File(os.path.join('test_data', 'test.biom'),
                                   'r'))
         os.chdir(cwd)
@@ -298,21 +298,21 @@ class ParseTests(TestCase):
     def test_load_table_filepath(self):
         cwd = os.getcwd()
         if os.path.sep in __file__[1:]:
-            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
+            os.chdir(os.path.dirname(__file__))
         load_table(os.path.join('test_data', 'test.biom'))
         os.chdir(cwd)
 
     def test_load_table_inmemory(self):
         cwd = os.getcwd()
         if os.path.sep in __file__[1:]:
-            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
+            os.chdir(os.path.dirname(__file__))
         load_table(h5py.File(os.path.join('test_data', 'test.biom'), 'r'))
         os.chdir(cwd)
 
     def test_load_table_inmemory_json(self):
         cwd = os.getcwd()
         if os.path.sep in __file__[1:]:
-            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
+            os.chdir(os.path.dirname(__file__))
         load_table(open(os.path.join('test_data', 'test.json')))
         os.chdir(cwd)
 
@@ -352,7 +352,7 @@ class ParseTests(TestCase):
         # We will round-trip the HDF5 file to several different formats, and
         # make sure we can recover the same table using parse_biom_table
         if os.path.sep in __file__[1:]:
-            os.chdir(__file__.rsplit(os.path.sep, 1)[0])
+            os.chdir(os.path.dirname(__file__))
 
         t = parse_biom_table(h5py.File(os.path.join('test_data', 'test.biom'), 'r'))
 

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -1199,11 +1199,11 @@ class TableTests(TestCase):
             self.assertIn('observation', h5)
             self.assertIn('sample', h5)
             self.assertEqual(sorted(h5.attrs.keys()), sorted(['id', 'type',
-                                                            'format-url',
-                                                            'format-version',
-                                                            'generated-by',
-                                                            'creation-date',
-                                                            'shape', 'nnz']))
+                                                              'format-url',
+                                                              'format-version',
+                                                              'generated-by',
+                                                              'creation-date',
+                                                              'shape', 'nnz']))
 
             obs = Table.from_hdf5(h5)
             self.assertEqual(obs, self.st_rich)

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -1024,7 +1024,7 @@ class TableTests(TestCase):
             h5 = h5py.File(tmpfile.name, 'r')
             obs = Table.from_hdf5(h5)
             h5.close()
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
 
         self.assertEqual(obs, t)
 
@@ -1041,7 +1041,7 @@ class TableTests(TestCase):
             obs = Table.from_hdf5(h5)
             self.assertEqual(obs.create_date, current)
             h5.close()
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
 
         self.assertEqual(obs, t)
 
@@ -1053,7 +1053,7 @@ class TableTests(TestCase):
             h5 = h5py.File(tmpfile.name, 'w')
             t.to_hdf5(h5, 'tests')
             h5.close()
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
 
     def test_to_hdf5_empty_table_bug_619(self):
         """Successfully writes an empty OTU table in HDF5 format"""
@@ -1062,14 +1062,14 @@ class TableTests(TestCase):
             h5 = h5py.File(tmpfile.name, 'w')
             t.to_hdf5(h5, 'tests')
             h5.close()
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
 
         t = example_table.filter({}, inplace=False)
         with NamedTemporaryFile(delete=False) as tmpfile:
             h5 = h5py.File(tmpfile.name, 'w')
             t.to_hdf5(h5, 'tests')
             h5.close()
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
 
     def test_to_hdf5_missing_metadata_observation(self):
         # exercises a vlen_list
@@ -1081,7 +1081,7 @@ class TableTests(TestCase):
             with h5py.File(tmpfile.name, 'w') as h5:
                 t.to_hdf5(h5, 'tests')
             obs = load_table(tmpfile.name)
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
         self.assertEqual(obs.metadata(axis='observation'),
                          ({'taxonomy': None},
                           {'taxonomy': ['foo', 'baz']}))
@@ -1096,7 +1096,7 @@ class TableTests(TestCase):
             with h5py.File(tmpfile.name, 'w') as h5:
                 t.to_hdf5(h5, 'tests')
             obs = load_table(tmpfile.name)
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
         self.assertEqual(obs.metadata(axis='sample'),
                          ({'dat': ''},
                           {'dat': 'foo'}))
@@ -1111,7 +1111,7 @@ class TableTests(TestCase):
                 with self.assertRaisesRegex(ValueError,
                                             'inconsistent metadata'):
                     t.to_hdf5(h5, 'tests')
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
 
     def test_to_hdf5_inconsistent_metadata_categories_sample(self):
         t = Table(np.array([[0, 1], [2, 3]]), ['a', 'b'], ['c', 'd'],
@@ -1124,7 +1124,7 @@ class TableTests(TestCase):
                 with self.assertRaisesRegex(ValueError,
                                             'inconsistent metadata'):
                     t.to_hdf5(h5, 'tests')
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
 
     def test_to_hdf5_malformed_taxonomy(self):
         t = Table(np.array([[0, 1], [2, 3]]), ['a', 'b'], ['c', 'd'],
@@ -1135,7 +1135,7 @@ class TableTests(TestCase):
             with h5py.File(tmpfile.name, 'w') as h5:
                 t.to_hdf5(h5, 'tests')
             obs = load_table(tmpfile.name)
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
         self.assertEqual(obs.metadata(axis='observation'),
                          ({'taxonomy': ['foo', 'bar']},
                           {'taxonomy': ['foo', 'baz']}))
@@ -1150,7 +1150,7 @@ class TableTests(TestCase):
             h5 = h5py.File(tmpfile.name, 'w')
             st_rich.to_hdf5(h5, 'tests')
             h5.close()
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
 
     def test_to_hdf5_custom_formatters(self):
         self.st_rich = Table(self.vals,
@@ -1186,7 +1186,7 @@ class TableTests(TestCase):
                 self.assertNotEqual(m1['barcode'], m2['barcode'])
                 self.assertEqual(m1['barcode'].lower(), m2['barcode'])
             h5.close()
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
 
     def test_to_hdf5(self):
         """Write a file"""
@@ -1208,7 +1208,7 @@ class TableTests(TestCase):
             obs = Table.from_hdf5(h5)
             self.assertEqual(obs, self.st_rich)
             h5.close()
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
 
         # Test with a collapsed table
         with NamedTemporaryFile(delete=False) as tmpfile:
@@ -1254,7 +1254,7 @@ class TableTests(TestCase):
                 [{'collapsed_ids': ['a', 'c']},
                  {'collapsed_ids': ['b']}])
             self.assertEqual(obs, exp)
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
 
         # Test with table having a None on taxonomy
         with NamedTemporaryFile(delete=False) as tmpfile:
@@ -1279,7 +1279,7 @@ class TableTests(TestCase):
             obs = Table.from_hdf5(h5)
             h5.close()
             self.assertEqual(obs, t)
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
 
     def test_from_tsv(self):
         tab1_fh = StringIO(otu_table1)

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -1016,13 +1016,15 @@ class TableTests(TestCase):
                   ['c', 'd', 'e'])
         t.add_metadata({'a': {'a / problem': 10}, 'b': {'a / problem': 20}},
                        axis='observation')
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             h5 = h5py.File(tmpfile.name, 'w')
             t.to_hdf5(h5, 'tests')
             h5.close()
 
             h5 = h5py.File(tmpfile.name, 'r')
             obs = Table.from_hdf5(h5)
+            h5.close()
+        os.unlink(tmpfile.name)
 
         self.assertEqual(obs, t)
 
@@ -1030,7 +1032,7 @@ class TableTests(TestCase):
         t = Table(np.array([[0, 1, 2], [3, 4, 5]]), ['a', 'b'],
                   ['c', 'd', 'e'])
         current = datetime.now()
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             h5 = h5py.File(tmpfile.name, 'w')
             t.to_hdf5(h5, 'tests', creation_date=current)
             h5.close()
@@ -1038,6 +1040,8 @@ class TableTests(TestCase):
             h5 = h5py.File(tmpfile.name, 'r')
             obs = Table.from_hdf5(h5)
             self.assertEqual(obs.create_date, current)
+            h5.close()
+        os.unlink(tmpfile.name)
 
         self.assertEqual(obs, t)
 
@@ -1045,24 +1049,27 @@ class TableTests(TestCase):
         """Successfully writes an empty OTU table in HDF5 format"""
         # Create an empty OTU table
         t = Table([], [], [])
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             h5 = h5py.File(tmpfile.name, 'w')
             t.to_hdf5(h5, 'tests')
             h5.close()
+        os.unlink(tmpfile.name)
 
     def test_to_hdf5_empty_table_bug_619(self):
         """Successfully writes an empty OTU table in HDF5 format"""
         t = example_table.filter({}, axis='observation', inplace=False)
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             h5 = h5py.File(tmpfile.name, 'w')
             t.to_hdf5(h5, 'tests')
             h5.close()
+        os.unlink(tmpfile.name)
 
         t = example_table.filter({}, inplace=False)
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             h5 = h5py.File(tmpfile.name, 'w')
             t.to_hdf5(h5, 'tests')
             h5.close()
+        os.unlink(tmpfile.name)
 
     def test_to_hdf5_missing_metadata_observation(self):
         # exercises a vlen_list
@@ -1070,10 +1077,11 @@ class TableTests(TestCase):
                   [{'taxonomy': None},
                    {'taxonomy': ['foo', 'baz']}])
 
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             with h5py.File(tmpfile.name, 'w') as h5:
                 t.to_hdf5(h5, 'tests')
             obs = load_table(tmpfile.name)
+        os.unlink(tmpfile.name)
         self.assertEqual(obs.metadata(axis='observation'),
                          ({'taxonomy': None},
                           {'taxonomy': ['foo', 'baz']}))
@@ -1084,10 +1092,11 @@ class TableTests(TestCase):
                   [{'dat': None},
                    {'dat': 'foo'}])
 
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             with h5py.File(tmpfile.name, 'w') as h5:
                 t.to_hdf5(h5, 'tests')
             obs = load_table(tmpfile.name)
+        os.unlink(tmpfile.name)
         self.assertEqual(obs.metadata(axis='sample'),
                          ({'dat': ''},
                           {'dat': 'foo'}))
@@ -1097,11 +1106,12 @@ class TableTests(TestCase):
                   [{'taxonomy_A': 'foo; bar'},
                    {'taxonomy_B': 'foo; baz'}])
 
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             with h5py.File(tmpfile.name, 'w') as h5:
                 with self.assertRaisesRegex(ValueError,
                                             'inconsistent metadata'):
                     t.to_hdf5(h5, 'tests')
+        os.unlink(tmpfile.name)
 
     def test_to_hdf5_inconsistent_metadata_categories_sample(self):
         t = Table(np.array([[0, 1], [2, 3]]), ['a', 'b'], ['c', 'd'],
@@ -1109,21 +1119,23 @@ class TableTests(TestCase):
                   [{'dat_A': 'foo; bar'},
                    {'dat_B': 'foo; baz'}])
 
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             with h5py.File(tmpfile.name, 'w') as h5:
                 with self.assertRaisesRegex(ValueError,
                                             'inconsistent metadata'):
                     t.to_hdf5(h5, 'tests')
+        os.unlink(tmpfile.name)
 
     def test_to_hdf5_malformed_taxonomy(self):
         t = Table(np.array([[0, 1], [2, 3]]), ['a', 'b'], ['c', 'd'],
                   [{'taxonomy': 'foo; bar'},
                    {'taxonomy': 'foo; baz'}])
 
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             with h5py.File(tmpfile.name, 'w') as h5:
                 t.to_hdf5(h5, 'tests')
             obs = load_table(tmpfile.name)
+        os.unlink(tmpfile.name)
         self.assertEqual(obs.metadata(axis='observation'),
                          ({'taxonomy': ['foo', 'bar']},
                           {'taxonomy': ['foo', 'baz']}))
@@ -1134,9 +1146,11 @@ class TableTests(TestCase):
                         [{'foo': ['k__a', 'p__b']},
                          {'foo': ['k__a', 'p__c']}],
                         [{'barcode': 'aatt'}, {'barcode': 'ttgg'}])
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             h5 = h5py.File(tmpfile.name, 'w')
             st_rich.to_hdf5(h5, 'tests')
+            h5.close()
+        os.unlink(tmpfile.name)
 
     def test_to_hdf5_custom_formatters(self):
         self.st_rich = Table(self.vals,
@@ -1151,7 +1165,7 @@ class TableTests(TestCase):
             grp.create_dataset(name, shape=data.shape, dtype=H5PY_VLEN_STR,
                                data=data, compression=compression)
 
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             h5 = h5py.File(tmpfile.name, 'w')
             self.st_rich.to_hdf5(h5, 'tests',
                                  format_fs={'barcode': bc_formatter})
@@ -1172,10 +1186,11 @@ class TableTests(TestCase):
                 self.assertNotEqual(m1['barcode'], m2['barcode'])
                 self.assertEqual(m1['barcode'].lower(), m2['barcode'])
             h5.close()
+        os.unlink(tmpfile.name)
 
     def test_to_hdf5(self):
         """Write a file"""
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             h5 = h5py.File(tmpfile.name, 'w')
             self.st_rich.to_hdf5(h5, 'tests')
             h5.close()
@@ -1184,18 +1199,19 @@ class TableTests(TestCase):
             self.assertIn('observation', h5)
             self.assertIn('sample', h5)
             self.assertEqual(sorted(h5.attrs.keys()), sorted(['id', 'type',
-                                                              'format-url',
-                                                              'format-version',
-                                                              'generated-by',
-                                                              'creation-date',
-                                                              'shape', 'nnz']))
+                                                            'format-url',
+                                                            'format-version',
+                                                            'generated-by',
+                                                            'creation-date',
+                                                            'shape', 'nnz']))
 
             obs = Table.from_hdf5(h5)
             self.assertEqual(obs, self.st_rich)
             h5.close()
+        os.unlink(tmpfile.name)
 
         # Test with a collapsed table
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             h5 = h5py.File(tmpfile.name, 'w')
             dt_rich = Table(
                 np.array([[5, 6, 7], [8, 9, 10], [11, 12, 13]]),
@@ -1238,9 +1254,10 @@ class TableTests(TestCase):
                 [{'collapsed_ids': ['a', 'c']},
                  {'collapsed_ids': ['b']}])
             self.assertEqual(obs, exp)
+        os.unlink(tmpfile.name)
 
         # Test with table having a None on taxonomy
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             h5 = h5py.File(tmpfile.name, 'w')
             t = Table(self.vals, ['1', '2'], ['a', 'b'],
                       [{'taxonomy': ['k__a', 'p__b']},
@@ -1262,6 +1279,7 @@ class TableTests(TestCase):
             obs = Table.from_hdf5(h5)
             h5.close()
             self.assertEqual(obs, t)
+        os.unlink(tmpfile.name)
 
     def test_from_tsv(self):
         tab1_fh = StringIO(otu_table1)

--- a/biom/tests/test_util.py
+++ b/biom/tests/test_util.py
@@ -265,9 +265,10 @@ class UtilTests(TestCase):
     def test_biom_open_hdf5_pathlib_write(self):
         t = Table(np.array([[0, 1, 2], [3, 4, 5]]), ['a', 'b'],
                   ['c', 'd', 'e'])
-        with NamedTemporaryFile() as tmpfile:
+        with NamedTemporaryFile(delete=False) as tmpfile:
             with biom_open(pathlib.Path(tmpfile.name), 'w') as fp:
                 t.to_hdf5(fp, 'tests')
+        os.unlink(tmpfile.name)
 
     def test_biom_open_hdf5_pathlib_read(self):
         cwd = os.getcwd()
@@ -317,8 +318,7 @@ class UtilTests(TestCase):
             fp.flush()
 
             obs = load_table(fp.name)
-            fp.close()
-            os.unlink(fp.name)
+        os.unlink(fp.name)
 
         npt.assert_equal(obs.ids(), tab.ids())
         npt.assert_equal(obs.ids(axis='observation'),

--- a/biom/tests/test_util.py
+++ b/biom/tests/test_util.py
@@ -246,11 +246,14 @@ class UtilTests(TestCase):
         tmp_f = NamedTemporaryFile(
             mode='w',
             prefix='test_safe_md5',
-            suffix='txt')
+            suffix='txt',
+            delete=False)
         tmp_f.write('foo\n')
         tmp_f.flush()
 
         obs = safe_md5(open(tmp_f.name))
+        tmp_f.close()
+        os.unlink(tmp_f.name)
         self.assertEqual(obs, exp)
 
         obs = safe_md5(['foo\n'])
@@ -309,11 +312,13 @@ class UtilTests(TestCase):
 
     def test_load_classic(self):
         tab = load_table(get_data_path('test.json'))
-        with NamedTemporaryFile(mode='w') as fp:
+        with NamedTemporaryFile(mode='w', delete=False) as fp:
             fp.write(str(tab))
             fp.flush()
 
             obs = load_table(fp.name)
+            fp.close()
+            os.unlink(fp.name)
 
         npt.assert_equal(obs.ids(), tab.ids())
         npt.assert_equal(obs.ids(axis='observation'),

--- a/biom/tests/test_util.py
+++ b/biom/tests/test_util.py
@@ -42,6 +42,12 @@ class UtilTests(TestCase):
 
     def setUp(self):
         self.biom_otu_table1_w_tax = parse_biom_table(biom_otu_table1_w_tax)
+        self.to_remove = []
+
+    def tearDown(self):
+        if self.to_remove:
+            for f in self.to_remove:
+                os.remove(f)
 
     def test_generate_subsamples(self):
         table = Table(np.array([[3, 1, 1], [0, 3, 3]]), ['O1', 'O2'],
@@ -253,7 +259,7 @@ class UtilTests(TestCase):
 
         obs = safe_md5(open(tmp_f.name))
         tmp_f.close()
-        os.unlink(tmp_f.name)
+        self.to_remove.append(tmp_f.name)
         self.assertEqual(obs, exp)
 
         obs = safe_md5(['foo\n'])
@@ -268,7 +274,7 @@ class UtilTests(TestCase):
         with NamedTemporaryFile(delete=False) as tmpfile:
             with biom_open(pathlib.Path(tmpfile.name), 'w') as fp:
                 t.to_hdf5(fp, 'tests')
-        os.unlink(tmpfile.name)
+        self.to_remove.append(tmpfile.name)
 
     def test_biom_open_hdf5_pathlib_read(self):
         cwd = os.getcwd()
@@ -318,7 +324,7 @@ class UtilTests(TestCase):
             fp.flush()
 
             obs = load_table(fp.name)
-        os.unlink(fp.name)
+        self.to_remove.append(fp.name)
 
         npt.assert_equal(obs.ids(), tab.ids())
         npt.assert_equal(obs.ids(axis='observation'),

--- a/ci/aarch64.conda_requirements.txt
+++ b/ci/aarch64.conda_requirements.txt
@@ -1,4 +1,3 @@
-natsort >= 4.0.3
 numpy >= 1.9.2
 pandas >= 0.20.0
 scipy >= 1.3.1

--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -1,4 +1,3 @@
-natsort >= 4.0.3
 numpy >= 1.9.2
 pandas >= 0.20.0
 scipy >= 1.3.1


### PR DESCRIPTION
@qiyunzhu Is this the preferred method for adding code to someone else's existing PR? With the current [PR #949](https://github.com/biocore/biom-format/pull/949) you have on BIOM's main branch, I believe if you accept these changes into your `windows` branch that they will be reflected in that PR (#949). If there is a better way to do this please let me know.

These changes fix all `FileNotFoundError`s which were present. All that was needed was to change the file separators from hard coded `'/'` which doesn't work with windows, to `os.path.sep`, and to use `os.path.join` on the file paths.